### PR TITLE
nvm command used before install

### DIFF
--- a/install
+++ b/install
@@ -16,10 +16,6 @@ apt-get install -y curl gnupg2
 curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash
 source ~/.bashrc
 
-# Initial install of NodeJS (vrsion 20 is an LTS version)
-nvm install v20
-npm install -g npm@latest
-
 # Install node version manager, globally
 mv ~/.nvm /opt/nvm
 chmod -R 755 /opt/nvm
@@ -27,6 +23,10 @@ export NVM_DIR="/opt/nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 export PATH="/opt/nvm:$PATH"
+
+# Initial install of NodeJS (vrsion 20 is an LTS version)
+nvm install v20
+npm install -g npm@latest
 
 # Install last three NodeJS LTS versions
 nvm install v16


### PR DESCRIPTION
Was getting `nvm: command not found` on a fresh install. Should start using nvm after installation and not before.